### PR TITLE
feat(cloudflare): integrate Cloudflare adapter and update dependencies

### DIFF
--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -5,10 +5,14 @@ import { defineConfig } from "astro/config";
 
 import mdx from "@astrojs/mdx";
 
+import cloudflare from "@astrojs/cloudflare";
+
 // https://astro.build/config
 export default defineConfig({
   vite: {
     plugins: [tailwindcss()],
   },
+
   integrations: [icon(), mdx()],
+  adapter: cloudflare(),
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,7 @@
     "astro": "astro"
   },
   "dependencies": {
+    "@astrojs/cloudflare": "^12.5.1",
     "@astrojs/mdx": "^4.2.5",
     "@iconify-json/bxl": "^1.2.2",
     "@iconify-json/lucide": "^1.2.39",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@astrojs/cloudflare':
+        specifier: ^12.5.1
+        version: 12.5.1(@types/node@22.14.0)(astro@5.7.5(@types/node@22.14.0)(aws4fetch@1.0.20)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.3)(rollup@4.37.0)(sass@1.86.0)(terser@5.16.9)(typescript@5.8.2)(yaml@2.7.0))(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.3)(sass@1.86.0)(terser@5.16.9)(yaml@2.7.0)
       '@astrojs/mdx':
         specifier: ^4.2.5
         version: 4.2.5(astro@5.7.5(@types/node@22.14.0)(aws4fetch@1.0.20)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.3)(rollup@4.37.0)(sass@1.86.0)(terser@5.16.9)(typescript@5.8.2)(yaml@2.7.0))
@@ -300,6 +303,11 @@ packages:
     resolution: {integrity: sha512-3ucaaSxV6fxXoqHrE/rxAvP1THnDdY5jNzGlnvx+JvnY9C/dSRKc0jlRMRz59N3El572+/yNRUUpAV1T9aBJug==}
     engines: {node: '>= 10'}
 
+  '@astrojs/cloudflare@12.5.1':
+    resolution: {integrity: sha512-J7LpDw7G/u/7/+XLx/zNFRwSJxPb+CimFSdJrQsHEXSzheJnqL8lExfiG/P94aJyEMa1aw5R5ECFqnEjdbbjRw==}
+    peerDependencies:
+      astro: ^5.0.0
+
   '@astrojs/compiler@2.11.0':
     resolution: {integrity: sha512-zZOO7i+JhojO8qmlyR/URui6LyfHJY6m+L9nwyX5GiKD78YoRaZ5tzz6X0fkl+5bD3uwlDHayf6Oe8Fu36RKNg==}
 
@@ -322,6 +330,9 @@ packages:
   '@astrojs/telemetry@3.2.1':
     resolution: {integrity: sha512-SSVM820Jqc6wjsn7qYfV9qfeQvePtVc1nSofhyap7l0/iakUKywj3hfy3UJAOV4sGV4Q/u450RD4AaCaFvNPlg==}
     engines: {node: ^18.17.1 || ^20.3.0 || >=22.0.0}
+
+  '@astrojs/underscore-redirects@0.6.1':
+    resolution: {integrity: sha512-4bMLrs2KW+8/vHEE5Ffv2HbxCbbgXO+2N6MpoCsMXUlUoi7pgEEx8kbkzMXJ2dZtWF3gvwm9lvgjnFeanC2LGg==}
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -7387,6 +7398,30 @@ snapshots:
       '@ast-grep/napi-win32-ia32-msvc': 0.35.0
       '@ast-grep/napi-win32-x64-msvc': 0.35.0
 
+  '@astrojs/cloudflare@12.5.1(@types/node@22.14.0)(astro@5.7.5(@types/node@22.14.0)(aws4fetch@1.0.20)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.3)(rollup@4.37.0)(sass@1.86.0)(terser@5.16.9)(typescript@5.8.2)(yaml@2.7.0))(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.3)(sass@1.86.0)(terser@5.16.9)(yaml@2.7.0)':
+    dependencies:
+      '@astrojs/internal-helpers': 0.6.1
+      '@astrojs/underscore-redirects': 0.6.1
+      '@cloudflare/workers-types': 4.20250404.0
+      astro: 5.7.5(@types/node@22.14.0)(aws4fetch@1.0.20)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.3)(rollup@4.37.0)(sass@1.86.0)(terser@5.16.9)(typescript@5.8.2)(yaml@2.7.0)
+      tinyglobby: 0.2.13
+      vite: 6.3.3(@types/node@22.14.0)(jiti@2.4.2)(less@4.2.2)(lightningcss@1.29.3)(sass@1.86.0)(terser@5.16.9)(yaml@2.7.0)
+      wrangler: 4.7.1(@cloudflare/workers-types@4.20250404.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - utf-8-validate
+      - yaml
+
   '@astrojs/compiler@2.11.0': {}
 
   '@astrojs/internal-helpers@0.6.1': {}
@@ -7451,6 +7486,8 @@ snapshots:
       which-pm-runs: 1.1.0
     transitivePeerDependencies:
       - supports-color
+
+  '@astrojs/underscore-redirects@0.6.1': {}
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:


### PR DESCRIPTION
- Added `@astrojs/cloudflare` as a dependency and configured it in the Astro setup.
- Updated `pnpm-lock.yaml` to include the new Cloudflare adapter version and its peer dependencies.
- Ensured compatibility with the latest Astro version by updating related packages.